### PR TITLE
CapturePreview

### DIFF
--- a/gphoto2go.go
+++ b/gphoto2go.go
@@ -20,6 +20,9 @@ type Camera struct {
 	camera  *C.Camera
 	context *C.GPContext
 }
+type CameraFile struct {
+	file *C.CameraFile
+}
 
 type CameraFilePath struct {
 	Name   string
@@ -315,4 +318,20 @@ func (c *Camera) DeleteFile(folder, file string) int {
 	filePointer := (*C.char)(unsafe.Pointer(&fileBytes[0]))
 	err := C.gp_camera_file_delete(c.camera, folderPointer, filePointer, c.context)
 	return int(err)
+}
+
+func (c *Camera) CapturePreview() (cf CameraFile, err int) {
+	C.gp_file_new(&cf.file)
+	err = int(C.gp_camera_capture_preview(
+		c.camera,
+		cf.file,
+		c.context))
+	getPreviewFile(&cf)
+	return cf, err
+
+}
+func getPreviewFile(file *CameraFile) {
+	var cSize C.ulong
+	var buf *C.char
+	C.gp_file_get_data_and_size(file.file, &buf, &cSize)
 }

--- a/gphoto2go_test.go
+++ b/gphoto2go_test.go
@@ -1,0 +1,17 @@
+package gphoto2go
+
+import "testing"
+
+func TestCapturePreviewSanity(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("Expected capture to work")
+		}
+	}()
+	cam := &Camera{}
+	cam.Init()
+	_, i := cam.CapturePreview()
+	if i != 0 {
+		t.Fatalf("Expected 0, got %d. Camera must be on", i)
+	}
+}


### PR DESCRIPTION
Support capturing preview images from usb-controlled camera models.

## Purpose 

Capture live preview images from an attached camera

## Usage

```
camera := Camera{}
camera.Init()
cameraFile, errInt := camera.CapturePreview()
if errInt != 0 {
    // problems
}
(*C.CameraFile)(cameraFile.file)
```